### PR TITLE
MapSwap updates

### DIFF
--- a/templates/images/georeference_interface.html
+++ b/templates/images/georeference_interface.html
@@ -1021,10 +1021,10 @@ document.addEventListener('DOMContentLoaded', function() {
         const mapswapLink = document.getElementById('mapswap-link');
         if (mapswapLink && map) {
             const center = map.getCenter();
-            const zoom = Math.round(map.getZoom());
+            const zoom = map.getZoom();
             const lat = center.lat.toFixed(6);
             const lng = center.lng.toFixed(6);
-            const url = `https://mapswap.trailsta.sh/swap/#type=l&url=https%3A%2F%2Fwww.openstreetmap.org%2F%23map%3D${zoom}%2F${lat}%2F${lng}`;
+            const url = `https://mapswap.trailsta.sh/swap/#type=m&url=geo:${lat},${lng};z=${zoom}`;
             mapswapLink.href = url;
         }
     }

--- a/templates/images/georeference_interface.html
+++ b/templates/images/georeference_interface.html
@@ -1021,7 +1021,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const mapswapLink = document.getElementById('mapswap-link');
         if (mapswapLink && map) {
             const center = map.getCenter();
-            const zoom = map.getZoom();
+            const zoom = map.getZoom().toFixed(2);
             const lat = center.lat.toFixed(6);
             const lng = center.lng.toFixed(6);
             const url = `https://mapswap.trailsta.sh/swap/#type=m&url=geo:${lat},${lng};z=${zoom}`;

--- a/templates/images/image_detail.html
+++ b/templates/images/image_detail.html
@@ -271,7 +271,7 @@
                             {% endif %}
                             <div class="col-md-4">
                                 <small class="text-muted d-block">Map Tools</small>
-                                <a href="https://mapswap.trailsta.sh/swap/#type=l&url=https%3A%2F%2Fwww.openstreetmap.org%2F%23map%3D18%2F{{ image.get_georeference.latitude }}%2F{{ image.get_georeference.longitude }}"
+                                <a href="https://mapswap.trailsta.sh/swap/#url=geo:{{ image.get_georeference.latitude }},{{ image.get_georeference.longitude }};z=18"
                                    target="_blank" class="btn btn-outline-primary btn-sm">
                                     MapSwap
                                 </a>


### PR DESCRIPTION
Made  few changes to the MapSwap integration.

* uses `geo:` URI
* specify `type=m` param (Mapbox/MapLibre style zoom-level) for the integration on reference page
* removed the `type=l` param (Leaflet style zoom-level) for image detail (unneeded. that's the default)
* uses floating point zoom level. MapSwap handles this for services that require integer zooms