### PR TITLE
nominatim params for improved performance

### DIFF
--- a/templates/images/georeference_interface.html
+++ b/templates/images/georeference_interface.html
@@ -1676,7 +1676,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     const request =
             `https://nominatim.openstreetmap.org/search?q=${
                 config.query
-            }&format=geojson&polygon_geojson=1&addressdetails=1`;
+            }&format=geojson&polygon_geojson=1&addressdetails=1&layer=address&viewbox=-77.61976,37.60954,-77.36673,37.44393&bounded=1`;
                     const response = await fetch(request);
                     const geojson = await response.json();
                     for (const feature of geojson.features) {


### PR DESCRIPTION
layer=address - only return address objects
viewbox=... - bounding box around richmond (might want to have more generic for this repo?) 
bounded=1 - limit results to viewbox area

tbh though, it might also work to just add "richmond va" to the end of every query?

I tested it a bit, but hopefully it won't be _too_ restrictive in returning fuzzy results