### PR TITLE
Add fix for geocoder search on mobile

### DIFF
--- a/templates/images/georeference_interface.html
+++ b/templates/images/georeference_interface.html
@@ -1715,6 +1715,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         map.addControl(geocoder, 'top-left');
 
+        // fix geocoder search on mobile chrome
+        const geocoderInput = document.getElementsByClassName("maplibregl-ctrl-geocoder--input")[0];
+        geocoderInput.type = "search";
+
         // Initialize MapSwap link and update on map move
         updateMapSwapLink();
         map.on('moveend', updateMapSwapLink);


### PR DESCRIPTION
Added a couple lines of js to change the search box input type from "text" to "search"
This fixes the behavior on mobile devices, and doesn't seem to affect anything else.