### PR TITLE
Fix commenter name in dark mode

### DIFF
--- a/templates/images/image_detail.html
+++ b/templates/images/image_detail.html
@@ -1405,7 +1405,7 @@
                                                 Comment by
                                                 {% if comment.commented_by.get_profile_url %}
                                                     <strong>
-                                                        <a href="{{ comment.commented_by.get_profile_url }}" target="_blank" class="text-decoration-none text-dark">
+                                                        <a href="{{ comment.commented_by.get_profile_url }}" target="_blank" class="text-decoration-none text-body">
                                                             {{ comment.commented_by.get_display_name }}
                                                             <i class="fas fa-external-link-alt ms-1 small text-muted"></i>
                                                         </a>


### PR DESCRIPTION
I didn't test this change, merge with caution.

Commenter name in the image details timeline in invisible in dark mode:

<img width="419" height="241" alt="image" src="https://github.com/user-attachments/assets/af95019a-d556-47b6-b98d-9bc59608591e" />

(That's https://yesterdays.maprva.org/14/)

I don't know if this affects only the comment timeline items (e.g. "Georeferenced by" is correct, but there are other timeline item types as well)