### PR TITLE
change og image from permalink to thumbnail

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -7,7 +7,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="{{ site_subtitle }}">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/images/browse_sources.html
+++ b/templates/images/browse_sources.html
@@ -8,7 +8,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="Browse {{ overall_stats.total_sources }} image archive{{ overall_stats.total_sources|pluralize }} with {{ overall_stats.total_images }} image{{ overall_stats.total_images|pluralize }}.">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/images/collection_detail.html
+++ b/templates/images/collection_detail.html
@@ -9,7 +9,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="{% if collection.description %}{{ collection.description }}{% else %}Collection of {{ total_images }} image{{ total_images|pluralize }} from {{ source.name }}.{% endif %}">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/images/favorites.html
+++ b/templates/images/favorites.html
@@ -9,7 +9,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="Explore our community's favorite images on Yesterdays.">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/images/from_above.html
+++ b/templates/images/from_above.html
@@ -9,7 +9,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="Explore {{ total_images }} image{{ total_images|pluralize }} taken from above.">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/images/image_detail.html
+++ b/templates/images/image_detail.html
@@ -6,7 +6,7 @@
 {% block opengraph %}
 	<meta property="og:title" content="{% if image.title %}{{ image.title }}{% else %}Image from {{ image.collection.source.name }}{% endif %} – Yesterdays">
 	<meta property="og:type" content="website">
-	<meta property="og:image" content="{{ image.permalink }}">
+	<meta property="og:image" content="{{ image.thumbnail }}">
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="Image from {{ image.collection.source.name }}, {{ image.collection.name }}.">
 {% endblock %}

--- a/templates/images/source_detail.html
+++ b/templates/images/source_detail.html
@@ -8,7 +8,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="{% if source.description %}{{ source.description }}{% else %}Archive with {{ collections.count }} collection{{ collections.count|pluralize }} and {{ total_images }} image{{ total_images|pluralize }}.{% endif %}">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/subjects/browse_subjects.html
+++ b/templates/subjects/browse_subjects.html
@@ -9,7 +9,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="Explore {{ overall_stats.total_subjects }} subject{{ overall_stats.total_subjects|pluralize }} totalling {{ overall_stats.total_images }} image{{ overall_stats.total_images|pluralize }}.">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}

--- a/templates/subjects/subject_detail.html
+++ b/templates/subjects/subject_detail.html
@@ -9,7 +9,7 @@
 	<meta property="og:url" content="{{ request.build_absolute_uri }}">
 	<meta property="og:description" content="{% if subject.wikidata_item.description %}{{ subject.wikidata_item.description }}{% else %}Browse {{ total_images }} image{{ total_images|pluralize }} featuring {{ subject.title }}.{% endif %}">
 	{% if top_rated_image %}
-	<meta property="og:image" content="{{ top_rated_image.permalink }}">
+	<meta property="og:image" content="{{ top_rated_image.thumbnail }}">
 	<meta property="og:image:alt" content="{{ top_rated_image.title }}">
 	{% endif %}
 {% endblock %}


### PR DESCRIPTION
Minor suggestion - when I went to share Yesterdays pages on social media I noticed they weren't showing image previews, and it turns out that a lot of the images are too big for OpenGraph (recommended 630k max filesize, 1200x630px max res)

But the thumbnails are still ok resolution (500x3xx), and looked good in my testing! So I'd like to suggest switching the og:image tags to use them instead.

before:
<img width="567" height="79" alt="image" src="https://github.com/user-attachments/assets/ab22583c-ae62-4df8-9090-2b5b33ead9c3" />

after:
<img width="552" height="353" alt="image" src="https://github.com/user-attachments/assets/45a60b95-f7de-4d8a-a3db-86dc7d66a296" />
