### PR TITLE
Drop PDFs and URLs from RPL collections

### DIFF
--- a/images/management/commands/importers/rpl.py
+++ b/images/management/commands/importers/rpl.py
@@ -134,6 +134,12 @@ def process_items(
                 pbar.update(1)
                 continue
 
+             # Don't get things that aren't images -- here PDFs and URLs (videos)
+            if item.get("filetype") == "pdf" or item.get("filetype") == "url":
+                print("    ✗ Item is not an image, skipping")
+                pbar.update(1)
+                continue
+
             # Build URLs
             original_url = f"{BASE_VIEWER_URL}/{collection_code}/id/{contentdm_id}"
             image_url = (


### PR DESCRIPTION
This PR drops items with a listed `filetype` of "pdf" or "url". There is a chance that there are further types we do not want, but I didn't want to risk saying what we only accept JPEG/PNG/TIFF and accidentally skipping novel formats or differently-encoded types ("JPG"/"TIF", e.g.).