### PR TITLE
Add env vars for a deployment's city and state

### DIFF
--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -122,9 +122,8 @@ export PG_SSL_MODE=disable
 export CELERY_BROKER_URL=amqp://guest:guest@localhost:5672//
 
 # Deployment specific
-# Comma separated list of cities and states that your deployment will encompass
-export CITIES=Richmond
-export STATES=Virginia
+export CITY=Richmond
+export STATE=Virginia
 
 # Local Development Settings
 export LOCAL_DEV=0

--- a/docs/development/environment.md
+++ b/docs/development/environment.md
@@ -121,6 +121,11 @@ export PG_SSL_MODE=disable
 # RabbitMQ Connection
 export CELERY_BROKER_URL=amqp://guest:guest@localhost:5672//
 
+# Deployment specific
+# Comma separated list of cities and states that your deployment will encompass
+export CITIES=Richmond
+export STATES=Virginia
+
 # Local Development Settings
 export LOCAL_DEV=0
 export ALLOW_HARDCODED_ADMIN=1

--- a/images/management/commands/importers/library_of_congress.py
+++ b/images/management/commands/importers/library_of_congress.py
@@ -21,8 +21,8 @@ from images.utils import R2Uploader
 POLITE_WAIT_SECS = 3.0  # 3 seconds as requested for LoC rate limiting
 
 
-CITIES = os.getenv("CITIES", "Richmond").split(",")
-STATES = os.getenv("STATES", "Virginia").split(",")
+CITY = os.getenv("CITY", "Richmond")
+STATE = os.getenv("STATE", "Virginia")
 
 
 def create_source_if_not_exist():
@@ -143,8 +143,8 @@ def create_collection_if_not_exist(source, collection_info):
 def fetch_loc_results(collection_slug, start_page=1, items_per_page=150):
     """Fetch results from Library of Congress API"""
     base_url = f"https://www.loc.gov/collections/{collection_slug}/"
-    city_search = "|".join(f"location:{city.lower()}" for city in CITIES)
-    state_search = "|".join(f"location:{state.lower()}" for state in STATES)
+    city_search = f"location:{CITY.lower()}"
+    state_search = f"location:{STATE.lower()}"
     params = {
         "fa": f"{state_search}|{city_search}",
         "fo": "json",

--- a/images/management/commands/importers/library_of_congress.py
+++ b/images/management/commands/importers/library_of_congress.py
@@ -8,7 +8,7 @@ Usage:
 
 The script will interactively prompt for collection details.
 """
-
+import os
 import re
 from time import sleep
 
@@ -19,6 +19,10 @@ from images.models import Collection, Image, Source
 from images.utils import R2Uploader
 
 POLITE_WAIT_SECS = 3.0  # 3 seconds as requested for LoC rate limiting
+
+
+CITIES = os.getenv("CITIES", "Richmond").split(",")
+STATES = os.getenv("STATES", "Virginia").split(",")
 
 
 def create_source_if_not_exist():
@@ -139,8 +143,10 @@ def create_collection_if_not_exist(source, collection_info):
 def fetch_loc_results(collection_slug, start_page=1, items_per_page=150):
     """Fetch results from Library of Congress API"""
     base_url = f"https://www.loc.gov/collections/{collection_slug}/"
+    city_search = "|".join(f"location:{city.lower()}" for city in CITIES)
+    state_search = "|".join(f"location:{state.lower()}" for state in STATES)
     params = {
-        "fa": "location:virginia|location:richmond",  # Hard-coded search params
+        "fa": f"{state_search}|{city_search}",
         "fo": "json",
         "c": items_per_page,
         "sp": start_page,


### PR DESCRIPTION
Creates environment variables for a deployment's city and state. For now this just overwrites the Library of Congress import, but in the future these can be used to replace other search terms and text throughout the app.

I attempted to make a multi-city search, but LoC search does not seem to support that. In the future we could just write a for loop, but that is too much for right now.

Closes #159 