### PR TITLE
Sitewide and Subject RSS feed

### DIFF
--- a/activity/feeds.py
+++ b/activity/feeds.py
@@ -1,0 +1,74 @@
+from itertools import chain
+from operator import attrgetter
+
+from django.contrib.syndication.views import Feed
+from django.utils.feedgenerator import Rss201rev2Feed
+
+
+from activity.models import (
+    GeoreferenceGroup,
+    SitewideMilestone,
+    SubjectIntroduction,
+    UserMilestone,
+)
+
+MAX_ITEMS = 50
+
+
+class SitewideActivityFeed(Feed):
+    """
+    Site-wide RSS feed showing the latest image additions.
+    """
+    feed_type = Rss201rev2Feed
+    title = "Yesterdays - Site-wide Activity"
+    link = "/activity/"  # Update with your main activity page URL
+    description = "The latest historical images, georeferences, and tags from Yesterdays."
+
+    def items(self):
+        # Fetch the most recent items of each activity type.
+        # Adjust 'created_at' to match your actual datetime field (e.g., 'timestamp').
+        georefs = GeoreferenceGroup.objects.all().order_by('-created_at')[:MAX_ITEMS]
+        subjects = SubjectIntroduction.objects.all().order_by('-created_at')[:MAX_ITEMS]
+        user_milestones = UserMilestone.objects.all().order_by('-created_at')[:MAX_ITEMS]
+        sitewide_milestones = SitewideMilestone.objects.all().order_by('-created_at')[:MAX_ITEMS]
+
+        # Chain them together and sort chronologically
+        combined = sorted(
+            chain(georefs, subjects, user_milestones, sitewide_milestones),
+            key=attrgetter('created_at'),
+            reverse=True
+        )
+        return combined[:MAX_ITEMS]
+
+    def item_title(self, item):
+        if isinstance(item, GeoreferenceGroup):
+            return f"Images georeferenced by {getattr(item, 'user', 'a user')}"
+        elif isinstance(item, SubjectIntroduction):
+            return f"New subject added: {item.subject.title}"
+        elif isinstance(item, UserMilestone):
+            return f"{item.user.username} reached {item.count} georeferences!"
+        elif isinstance(item, SitewideMilestone):
+            return f"Yesterdays reached {item.count} images georeferenced!"
+        return str(item)
+
+    def item_description(self, item):
+        if isinstance(item, GeoreferenceGroup):
+            count = getattr(item, 'count', 'Multiple')
+            return f"{count} images were recently georeferenced."
+        elif isinstance(item, SubjectIntroduction):
+            return "A new subject was introduced to the catalog."
+        elif isinstance(item, UserMilestone):
+            return "A user has reached a new georeferencing milestone."
+        elif isinstance(item, SitewideMilestone):
+            return "The community has reached a new site-wide milestone."
+        return str(item)
+
+    def item_link(self, item):
+        if hasattr(item, 'get_absolute_url'):
+            return item.get_absolute_url()
+        if isinstance(item, SubjectIntroduction) and hasattr(item, 'subject'):
+            return f"/subjects/{item.subject.pk}/"
+        return "/activity/"
+
+    def item_pubdate(self, item):
+        return getattr(item, 'created_at', None)

--- a/activity/feeds.py
+++ b/activity/feeds.py
@@ -1,7 +1,9 @@
+import uuid
 from itertools import chain
 from operator import attrgetter
 
 from django.contrib.syndication.views import Feed
+from django.urls import reverse
 from django.utils.feedgenerator import Rss201rev2Feed
 
 
@@ -36,8 +38,8 @@ class SitewideActivityFeed(Feed):
         # Chain them together and sort chronologically
         combined = sorted(
             chain(georefs, subjects, user_milestones, sitewide_milestones, collections),
-            key=attrgetter('created_at'),
-            reverse=True
+            key=attrgetter('created_at', 'reached_at', 'ended_at'),
+            reverse=True,
         )
         return combined[:MAX_ITEMS]
 
@@ -69,11 +71,25 @@ class SitewideActivityFeed(Feed):
         return str(item)
 
     def item_link(self, item):
+        # Default to method if the model has one. Covers Image, Subject, Collection
         if hasattr(item, 'get_absolute_url'):
             return item.get_absolute_url()
-        if isinstance(item, SubjectIntroduction) and hasattr(item, 'subject'):
-            return f"/subjects/{item.subject.pk}/"
+        elif isinstance(item, SubjectIntroduction):
+            return item.subject.get_absolute_url()
+        elif isinstance(item, UserMilestone):
+            return reverse("user_profile", kwargs={"username": item.user.username})
+        elif isinstance(item, CollectionIntroduction):
+            return item.collection.get_absolute_url()
+
+        # GeoreferenceGroup and SitewideMilestone go nowhere?
         return "/activity/"
 
     def item_pubdate(self, item):
-        return getattr(item, 'created_at', None)
+        return getattr(item, 'created_at', None) or getattr(item, 'reached_at', None) or getattr(item, 'ended_at', None)
+
+    def item_guid(self, item):
+        """
+        Set a random UUID for each item, so that the exact same session can appear in
+        multiple feeds if necessary and won't be filtered by RSS clients.
+        """
+        return str(uuid.uuid4())

--- a/activity/feeds.py
+++ b/activity/feeds.py
@@ -10,6 +10,7 @@ from activity.models import (
     SitewideMilestone,
     SubjectIntroduction,
     UserMilestone,
+    CollectionIntroduction,
 )
 
 MAX_ITEMS = 50
@@ -17,24 +18,24 @@ MAX_ITEMS = 50
 
 class SitewideActivityFeed(Feed):
     """
-    Site-wide RSS feed showing the latest image additions.
+    Site-wide RSS feed showing the latest georeferences, subjects, and milestones.
     """
     feed_type = Rss201rev2Feed
     title = "Yesterdays - Site-wide Activity"
     link = "/activity/"  # Update with your main activity page URL
-    description = "The latest historical images, georeferences, and tags from Yesterdays."
+    description = "The latest georeferences subjects, and milestones in Yesterdays."
 
     def items(self):
         # Fetch the most recent items of each activity type.
-        # Adjust 'created_at' to match your actual datetime field (e.g., 'timestamp').
-        georefs = GeoreferenceGroup.objects.all().order_by('-created_at')[:MAX_ITEMS]
-        subjects = SubjectIntroduction.objects.all().order_by('-created_at')[:MAX_ITEMS]
-        user_milestones = UserMilestone.objects.all().order_by('-created_at')[:MAX_ITEMS]
+        georefs = GeoreferenceGroup.objects.all().order_by('-ended_at')[:MAX_ITEMS]
+        user_milestones = UserMilestone.objects.all().order_by('-reached_at')[:MAX_ITEMS]
         sitewide_milestones = SitewideMilestone.objects.all().order_by('-created_at')[:MAX_ITEMS]
+        subjects = SubjectIntroduction.objects.all().order_by('-reached_at')[:MAX_ITEMS]
+        collections = CollectionIntroduction.objects.all().order_by('-created_at')[:MAX_ITEMS]
 
         # Chain them together and sort chronologically
         combined = sorted(
-            chain(georefs, subjects, user_milestones, sitewide_milestones),
+            chain(georefs, subjects, user_milestones, sitewide_milestones, collections),
             key=attrgetter('created_at'),
             reverse=True
         )
@@ -49,6 +50,8 @@ class SitewideActivityFeed(Feed):
             return f"{item.user.username} reached {item.count} georeferences!"
         elif isinstance(item, SitewideMilestone):
             return f"Yesterdays reached {item.count} images georeferenced!"
+        elif isinstance(item, CollectionIntroduction):
+            return f"New collection added: {item.collection.name}"
         return str(item)
 
     def item_description(self, item):
@@ -61,6 +64,8 @@ class SitewideActivityFeed(Feed):
             return "A user has reached a new georeferencing milestone."
         elif isinstance(item, SitewideMilestone):
             return "The community has reached a new site-wide milestone."
+        elif isinstance(item, CollectionIntroduction):
+            return "A new collection was introduced to the catalog."
         return str(item)
 
     def item_link(self, item):

--- a/activity/urls.py
+++ b/activity/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from . import views
+from activity import views
+from activity.feeds import SitewideActivityFeed
 
 app_name = "activity"
 
 urlpatterns = [
     path("", views.activity_feed, name="feed"),
+    path("feed/",SitewideActivityFeed(), name="site-feed")
 ]

--- a/api/tests.py
+++ b/api/tests.py
@@ -1108,3 +1108,41 @@ class TestAuthorizedApplicationsSettings(OAuthConsentFixturesMixin, TestCase):
         )
         self.assertEqual(resp.status_code, 404)
         self.assertTrue(ApplicationConsent.objects.filter(pk=consent.pk).exists())
+
+
+# ---------------------------------------------------------------------------
+# RSS Feeds
+# ---------------------------------------------------------------------------
+
+
+class TestSitewideActivityFeed(ApiFixturesMixin, TestCase):
+    def test_feed_status_and_type(self):
+        resp = self.client.get("/activity/feed/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "application/rss+xml; charset=utf-8")
+
+    def test_feed_content(self):
+        resp = self.client.get("/activity/feed/")
+        content = resp.content.decode("utf-8")
+        
+        self.assertIn('<rss version="2.0"', content)
+        self.assertIn("<title>Yesterdays - Site-wide Activity</title>", content)
+        # Based on the test fixtures, we should have a milestone in the activity feed
+        self.assertIn("milestone", content.lower())
+
+
+class TestSubjectActivityFeed(ApiFixturesMixin, TestCase):
+    def test_feed_status_and_type(self):
+        resp = self.client.get(f"/subjects/{self.subject.slug}/feed/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "application/rss+xml; charset=utf-8")
+
+    def test_feed_content(self):
+        resp = self.client.get(f"/subjects/{self.subject.slug}/feed/")
+        content = resp.content.decode("utf-8")
+        self.assertIn('<rss version="2.0"', content)
+        self.assertIn(self.img1.title, content)
+
+    def test_feed_404(self):
+        resp = self.client.get("/subjects/fake-subject/feed/")
+        self.assertEqual(resp.status_code, 404)

--- a/subjects/feeds.py
+++ b/subjects/feeds.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib.syndication.views import Feed
 from django.shortcuts import get_object_or_404
 from django.utils.feedgenerator import Rss201rev2Feed
@@ -43,3 +45,10 @@ class SubjectActivityFeed(Feed):
 
     def item_pubdate(self, image):
         return image.created_at
+
+    def item_guid(self, subject):
+        """
+        Set a random UUID for each item, so that the exact same session can appear in
+        multiple feeds if necessary and won't be filtered by RSS clients.
+        """
+        return str(uuid.uuid4())

--- a/subjects/feeds.py
+++ b/subjects/feeds.py
@@ -18,32 +18,28 @@ class SubjectActivityFeed(Feed):
     def title(self, subject):
         return f"Yesterdays - New images for {subject.name}"
 
-    def link(self, obj):
-        if hasattr(obj, 'get_absolute_url'):
-            return obj.get_absolute_url()
-        return f"/subjects/{obj.pk}/"
+    def link(self, subject):
+        return subject.get_absolute_url()
 
     def description(self, subject):
         return f"Latest images tagged with: {subject.name}."
 
-    def items(self, obj):
+    def items(self, subject):
         # Assuming SubjectMapping links Image and Subject via a ForeignKey to Subject.
         # The related lookup name (`subjectmapping__subject`) might need to be tweaked
         # depending on your exact ForeignKey setup in SubjectMapping.
         return Image.objects.filter(
-            subjectmapping__subject=obj
+            subjectmapping__subject=subject,
         ).distinct().order_by('-created_at')[:50]
 
-    def item_title(self, item):
-        return f"New image tagged: {item.title}"
+    def item_title(self, image):
+        return f"New image tagged: {image.title}"
 
-    def item_description(self, item):
-        return item.description
+    def item_description(self, image):
+        return image.description
 
     def item_link(self, item):
-        if hasattr(item, 'get_absolute_url'):
-            return item.get_absolute_url()
-        return f"/images/{item.pk}/"
+        return item.get_absolute_url()
 
-    def item_pubdate(self, item):
-        return getattr(item, 'created_at', None)
+    def item_pubdate(self, image):
+        return image.created_at

--- a/subjects/feeds.py
+++ b/subjects/feeds.py
@@ -1,0 +1,52 @@
+from django.contrib.syndication.views import Feed
+from django.shortcuts import get_object_or_404
+from django.utils.feedgenerator import Rss201rev2Feed
+
+from images.models import Image
+from subjects.models import Subject
+
+class SubjectActivityFeed(Feed):
+    """
+    Subject-specific RSS feed showing new photos tagged with a given subject.
+    """
+    feed_type = Rss201rev2Feed
+
+    def get_object(self, request, subject_id):
+        # Grabs the subject object when the URL is requested
+        return get_object_or_404(Subject, pk=subject_id)
+
+    def title(self, obj):
+        name = getattr(obj, 'name', f"Subject {obj.id}")
+        return f"Yesterdays - New images for {name}"
+
+    def link(self, obj):
+        if hasattr(obj, 'get_absolute_url'):
+            return obj.get_absolute_url()
+        return f"/subjects/{obj.pk}/"
+
+    def description(self, obj):
+        name = getattr(obj, 'name', f"Subject {obj.id}")
+        return f"Latest images tagged with: {name}."
+
+    def items(self, obj):
+        # Assuming SubjectMapping links Image and Subject via a ForeignKey to Subject.
+        # The related lookup name (`subjectmapping__subject`) might need to be tweaked
+        # depending on your exact ForeignKey setup in SubjectMapping.
+        return Image.objects.filter(
+            subjectmapping__subject=obj
+        ).distinct().order_by('-created_at')[:50]
+
+    def item_title(self, item):
+        title = getattr(item, 'title', f"Image {item.id}")
+        return f"New image tagged: {title}"
+
+    def item_description(self, item):
+        return getattr(item, 'description', 'A historical image was tagged with this subject.')
+
+    def item_link(self, item):
+        if hasattr(item, 'get_absolute_url'):
+            return item.get_absolute_url()
+        return f"/images/{item.pk}/"
+
+    def item_pubdate(self, item):
+        return getattr(item, 'created_at', None)

--- a/subjects/feeds.py
+++ b/subjects/feeds.py
@@ -11,22 +11,20 @@ class SubjectActivityFeed(Feed):
     """
     feed_type = Rss201rev2Feed
 
-    def get_object(self, request, subject_id):
+    def get_object(self, request, subject_slug):
         # Grabs the subject object when the URL is requested
-        return get_object_or_404(Subject, pk=subject_id)
+        return get_object_or_404(Subject, slug=subject_slug)
 
-    def title(self, obj):
-        name = getattr(obj, 'name', f"Subject {obj.id}")
-        return f"Yesterdays - New images for {name}"
+    def title(self, subject):
+        return f"Yesterdays - New images for {subject.name}"
 
     def link(self, obj):
         if hasattr(obj, 'get_absolute_url'):
             return obj.get_absolute_url()
         return f"/subjects/{obj.pk}/"
 
-    def description(self, obj):
-        name = getattr(obj, 'name', f"Subject {obj.id}")
-        return f"Latest images tagged with: {name}."
+    def description(self, subject):
+        return f"Latest images tagged with: {subject.name}."
 
     def items(self, obj):
         # Assuming SubjectMapping links Image and Subject via a ForeignKey to Subject.
@@ -37,11 +35,10 @@ class SubjectActivityFeed(Feed):
         ).distinct().order_by('-created_at')[:50]
 
     def item_title(self, item):
-        title = getattr(item, 'title', f"Image {item.id}")
-        return f"New image tagged: {title}"
+        return f"New image tagged: {item.title}"
 
     def item_description(self, item):
-        return getattr(item, 'description', 'A historical image was tagged with this subject.')
+        return item.description
 
     def item_link(self, item):
         if hasattr(item, 'get_absolute_url'):

--- a/subjects/urls.py
+++ b/subjects/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
-from . import views
+from subjects import views
+from subjects.feeds import SubjectActivityFeed
 
 app_name = "subjects"
 
@@ -9,6 +10,7 @@ urlpatterns = [
     path("", views.browse_subjects, name="browse_subjects"),
     path("map/", views.subjects_map, name="subjects_map"),
     path("<slug:subject_slug>/", views.subject_detail, name="subject_detail"),
+    path("<slug:subject_slug>/feed/", SubjectActivityFeed(), name="subject_feed"),
     path(
         "<slug:subject_slug>/similar/",
         views.find_similar_images_to_subject,


### PR DESCRIPTION
Creates two RSS feeds:

- Sitewide feed that mimics the activity feed
- Subject activity feed that shows images tagged with the subject

Closes #191